### PR TITLE
Use opis/closure 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Note: you may refer to `README.md` for description of features.
 
 ## Dev (WIP)
 - Task IDs can be given to tasks (generated or not) (https://github.com/Vectorial1024/laravel-process-async/issues/5)
+- Updated to use `opis/closure` 4.0 for task details serialization (https://github.com/Vectorial1024/laravel-process-async/issues/12)
+  - Technically a breaking internal change, but no code change expected and downtime is expected to be almost negligible
 
 ## 0.2.0 (2025-01-04)
 - Task runners are now detached from the task giver (https://github.com/Vectorial1024/laravel-process-async/issues/7)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Utilize Laravel Processes to run PHP code asynchronously, as if using Laravel Co
 ## What really is this?
 [Laravel Processes](https://laravel.com/docs/10.x/processes) was first introduced in Laravel 10. This library wraps around `Process::start()` to let you execute code in the background to achieve async, albeit with some caveats:
 - You may only execute PHP code
-- Restrictions from `laravel/serializable-closure` apply (see [their README](https://github.com/laravel/serializable-closure))
+- Restrictions from `opis/closure` apply (see [their README](https://github.com/opis/closure))
 - Hands-off execution: no built-in result-checking, check the results yourself (e.g. via database, file cache, etc)
 
 This library internally uses an Artisan command to run the async code, which is similar to Laravel 11 [Concurrency](https://laravel.com/docs/11.x/concurrency).

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0",
         "laravel/serializable-closure": "^1.0",
-        "loophp/phposinfo": "^1.8"
+        "loophp/phposinfo": "^1.8",
+        "opis/closure": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0",
-        "laravel/serializable-closure": "^2.0",
         "loophp/phposinfo": "^1.8",
         "opis/closure": "^4.0"
     },
@@ -51,5 +50,8 @@
                 "Vectorial1024\\LaravelProcessAsync\\ProcessAsyncServiceProvider"
             ]
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^10.0|^11.0",
-        "laravel/serializable-closure": "^1.0",
+        "laravel/serializable-closure": "^2.0",
         "loophp/phposinfo": "^1.8",
         "opis/closure": "^4.0"
     },

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -9,7 +9,6 @@ use Illuminate\Process\InvokedProcess;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use loophp\phposinfo\OsInfo;
 use RuntimeException;

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -129,7 +129,6 @@ class AsyncTask
             'theTask' => $this->theTask,
             'timeLimit' => $this->timeLimit,
         ] = $data;
-        // $this->theTask = unserialize($tempTask);
     }
 
     /**

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -99,6 +99,24 @@ class AsyncTask
         $this->theTask = $theTask;
     }
 
+    public function __serialize(): array
+    {
+        // serialize only the necessary info to reduce runner cmd length
+        return [
+            'theTask' => serialize($this->theTask),
+            'timeLimit' => $this->timeLimit,
+        ];
+    }
+
+    public function __unserialize($data): void
+    {
+        [
+            'theTask' => $tempTask,
+            'timeLimit' => $this->timeLimit,
+        ] = $data;
+        $this->theTask = unserialize($tempTask);
+    }
+
     /**
      * Inside an available PHP process, runs this AsyncTask instance.
      * 

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -103,7 +103,7 @@ class AsyncTask
     {
         // serialize only the necessary info to reduce runner cmd length
         return [
-            'theTask' => serialize($this->theTask),
+            'theTask' => $this->theTask,
             'timeLimit' => $this->timeLimit,
         ];
     }
@@ -111,10 +111,10 @@ class AsyncTask
     public function __unserialize($data): void
     {
         [
-            'theTask' => $tempTask,
+            'theTask' => $this->theTask,
             'timeLimit' => $this->timeLimit,
         ] = $data;
-        $this->theTask = unserialize($tempTask);
+        // $this->theTask = unserialize($tempTask);
     }
 
     /**


### PR DESCRIPTION
This upgrades the library to use `opis/closure`. No breaking changes are expected since it only changes our internal logic/workflow. Users of this library are not supposed to manually invoke our runners anyways.