### PR TITLE
Feature: task IDs (and other related stuff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Note: you may refer to `README.md` for description of features.
 
 ## Dev (WIP)
+- Task IDs can be given to tasks (generated or not) (https://github.com/Vectorial1024/laravel-process-async/issues/5)
 
 ## 0.2.0 (2025-01-04)
 - Task runners are now detached from the task giver (https://github.com/Vectorial1024/laravel-process-async/issues/7)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ Some tips:
   - Use short but frequent sleeps instead.
 - Avoid using `SIGINT`! On Unix, this signal is reserved for timeout detection. 
 
+### Task IDs
+You can assign task IDs to tasks before they are run, but you cannot change them after the tasks are started. This allows you to track the statuses of long-running tasks across web requests.
+
+By default, if a task does not has its user-specified task ID when starting, a ULID will be generated as its task ID.
+
+```php
+// create a task with a specified task ID...
+$task = new AsyncTask(function () {}, "customTaskID");
+
+// will return a status object for immediate checking...
+$status = $task->start();
+
+// in case the task ID was not given, what is the generated task ID?
+$taskID = $status->taskID;
+
+// is that task still running?
+$status->isRunning();
+
+// when task IDs are known, task status objects can be recreated on-the-fly
+$anotherStatus = new AsyncTaskStatus();
+```
+
+Some tips:
+- Task IDs can be optional (i.e. `null`) but CANNOT be blank (i.e. `""`)!
+- If multiple tasks are started with the same task ID, then the task status object will only track the first task that was started
+- Known issue: on Windows, checking task statuses can be slow (about 0.5 - 1 seconds) due to underlying bottlenecks
+
 ## Testing
 PHPUnit via Composer script:
 ```sh

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $taskID = $status->taskID;
 $status->isRunning();
 
 // when task IDs are known, task status objects can be recreated on-the-fly
-$anotherStatus = new AsyncTaskStatus();
+$anotherStatus = new AsyncTaskStatus("customTaskID");
 ```
 
 Some tips:

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -180,7 +180,8 @@ class AsyncTask
 
         // prepare the runner command
         $serializedTask = $this->toBase64Serial();
-        $baseCommand = "php artisan async:run $serializedTask";
+        $encodedTaskID = $taskStatus->getEncodedTaskID();
+        $baseCommand = "php artisan async:run $serializedTask --id='$encodedTaskID'";
 
         // then, specific actions depending on the runtime OS
         if (OsInfo::isWindows()) {

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Process\InvokedProcess;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
 use loophp\phposinfo\OsInfo;
@@ -109,6 +110,9 @@ class AsyncTask
             $theTask = new SerializableClosure($theTask);
         }
         $this->theTask = $theTask;
+        if ($taskID === "") {
+            throw new InvalidArgumentException("AsyncTask ID cannot be empty.");
+        }
         $this->taskID = $taskID;
     }
 

--- a/src/AsyncTask.php
+++ b/src/AsyncTask.php
@@ -25,6 +25,14 @@ class AsyncTask
     private SerializableClosure|AsyncTaskInterface $theTask;
 
     /**
+     * The user-specified ID of the current task. (Null means user did not specify any ID).
+     * 
+     * If null, the task will generate an unsaved random ID when it is started.
+     * @var string|null
+     */
+    private string|null $taskID;
+
+    /**
      * The process that is actually running this task. Tasks that are not started will have null here.
      * @var InvokedProcess|null
      */
@@ -92,14 +100,16 @@ class AsyncTask
     /**
      * Creates an AsyncTask instance.
      * @param Closure|AsyncTaskInterface $theTask The task to be executed in the background.
+     * @param string|null $taskID (optional) The user-specified task ID of this AsyncTask. Should be unique.
      */
-    public function __construct(Closure|AsyncTaskInterface $theTask)
+    public function __construct(Closure|AsyncTaskInterface $theTask, string|null $taskID = null)
     {
         if ($theTask instanceof Closure) {
             // convert to serializable closure first
             $theTask = new SerializableClosure($theTask);
         }
         $this->theTask = $theTask;
+        $this->taskID = $taskID;
     }
 
     /**
@@ -165,8 +175,7 @@ class AsyncTask
     public function start(): AsyncTaskStatus
     {
         // prepare the task details
-        // todo allow changing the task ID
-        $taskID = null ?? Str::ulid();
+        $taskID = $this->taskID ?? Str::ulid()->toString();
         $taskStatus = new AsyncTaskStatus($taskID);
 
         // prepare the runner command

--- a/src/AsyncTaskRunnerCommand.php
+++ b/src/AsyncTaskRunnerCommand.php
@@ -14,7 +14,7 @@ class AsyncTaskRunnerCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'async:run {task}';
+    protected $signature = 'async:run {task} {--id=}';
 
     /**
      * The console command description.

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -14,6 +14,12 @@ use RuntimeException;
 class AsyncTaskStatus
 {
     /**
+     * The cached task ID for quick ID reusing. We will most probably reuse this ID many times.
+     * @var string|null
+     */
+    private string|null $encodedTaskID = null;
+
+    /**
      * Constructs a status object.
      * @param string $taskID The task ID of the async task so to check its status.
      */
@@ -24,5 +30,17 @@ class AsyncTaskStatus
             // why no blank IDs? because this will produce blank output via base64 encode.
             throw new RuntimeException("AsyncTask IDs cannot be blank");
         }
+    }
+
+    /**
+     * Returns the task ID encoded in base64, mainly for result checking.
+     * @return string The encoded task ID.
+     */
+    public function getEncodedTaskID(): string
+    {
+        if ($this->encodedTaskID === null) {
+            $this->encodedTaskID = base64_encode($this->taskID);
+        }
+        return $this->encodedTaskID;
     }
 }

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -189,8 +189,8 @@ class AsyncTaskStatus
         // since we should have remembered the PID, we can just query whether it still exists
         // supposedly, the PID has not rolled over yet, right...?
         if (OsInfo::isWindows()) {
-            // Windows uses GCIM to discover processes
-            $echoedPid = exec("powershell echo \"\"(gcim Win32_Process -Filter \\\"ProcessId = {$this->lastKnownPID}\\\").ProcessId\"\"");
+            // Windows can also use Get-Process to probe processes
+            $echoedPid = exec("powershell (Get-Process -id {$this->lastKnownPID}).Id");
             if ($echoedPid === false) {
                 throw new RuntimeException(self::MSG_CANNOT_CHECK_STATUS);
             }

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -63,7 +63,7 @@ class AsyncTaskStatus
     }
 
     /**
-     * Returns whether the AsyncTask is still running.
+     * Checks and returns whether the AsyncTask is still running. This may take a bit of time.
      * 
      * Note: when this method detects that the task has stopped running, it will not recheck whether the task has restarted.
      * Use a fresh status object to track the (restarted) task.

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -153,7 +153,9 @@ class AsyncTaskStatus
         $results = [];
         $encodedTaskID = $this->getEncodedTaskID();
         exec("pgrep -f id='$encodedTaskID'", $results);
-        // supposedly there should be only 1 entry, but anyway
+        // we may find multiple records here if we are using timeouts
+        // this is because there will be one parent timeout process and another actual child artisan process
+        // we want the child artisan process
         $expectedCmdName = "artisan async:run";
         foreach ($results as $candidatePID) {
             $candidatePID = (int) $candidatePID;

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -20,6 +20,14 @@ class AsyncTaskStatus
     private string|null $encodedTaskID = null;
 
     /**
+     * Indicates whether the task is stopped.
+     * 
+     * Note: the criteria is "pretty sure it is stopped"; once the task is stopped, it stays stopped.
+     * @var bool
+     */
+    private bool $isStopped = false;
+
+    /**
      * Constructs a status object.
      * @param string $taskID The task ID of the async task so to check its status.
      */
@@ -42,5 +50,25 @@ class AsyncTaskStatus
             $this->encodedTaskID = base64_encode($this->taskID);
         }
         return $this->encodedTaskID;
+    }
+
+    /**
+     * Returns whether the AsyncTask is still running.
+     * 
+     * Note: when this method detects that the task has stopped running, it will not recheck whether the task has restarted.
+     * Use a fresh status object to track the (restarted) task.
+     * @return bool
+     */
+    public function isRunning(): bool
+    {
+        if ($this->isStopped) {
+            return false;
+        }
+        // prove it is running
+        $isRunning = false;
+        if (!$isRunning) {
+            $this->isStopped = true;
+        }
+        return $isRunning;
     }
 }

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -75,7 +75,7 @@ class AsyncTaskStatus
             return false;
         }
         // prove it is running
-        $isRunning = false;
+        $isRunning = $this->proveTaskIsRunning();
         if (!$isRunning) {
             $this->isStopped = true;
         }

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -63,7 +63,9 @@ class AsyncTaskStatus
     }
 
     /**
-     * Checks and returns whether the AsyncTask is still running. This may take a bit of time.
+     * Checks and returns whether the AsyncTask is still running.
+     * 
+     * On Windows, this may take some time due to underlying bottlenecks.
      * 
      * Note: when this method detects that the task has stopped running, it will not recheck whether the task has restarted.
      * Use a fresh status object to track the (restarted) task.

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -83,7 +83,7 @@ class AsyncTaskStatus
     }
 
     /**
-     * Attepts to prove whether the AsyncTask is still running
+     * Attempts to prove whether the AsyncTask is still running
      * @return bool If false, then the task is shown to have been stopped.
      */
     private function proveTaskIsRunning(): bool

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Vectorial1024\LaravelProcessAsync;
 
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Represents the status of an async task: "running" or "stopped".
@@ -28,7 +28,7 @@ class AsyncTaskStatus
     ) {
         if ($taskID === "") {
             // why no blank IDs? because this will produce blank output via base64 encode.
-            throw new RuntimeException("AsyncTask IDs cannot be blank");
+            throw new InvalidArgumentException("AsyncTask IDs cannot be blank");
         }
     }
 

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vectorial1024\LaravelProcessAsync;
+
+use RuntimeException;
+
+/**
+ * Represents the status of an async task: "running" or "stopped".
+ * 
+ * This does not tell you whether it was a success/failure, since it depends on the user's custom result checking.
+ */
+class AsyncTaskStatus
+{
+    /**
+     * Constructs a status object.
+     * @param string $taskID The task ID of the async task so to check its status.
+     */
+    public function __construct(
+        public readonly string $taskID
+    ) {
+        if ($taskID === "") {
+            // why no blank IDs? because this will produce blank output via base64 encode.
+            throw new RuntimeException("AsyncTask IDs cannot be blank");
+        }
+    }
+}

--- a/src/AsyncTaskStatus.php
+++ b/src/AsyncTaskStatus.php
@@ -28,6 +28,12 @@ class AsyncTaskStatus
     private bool $isStopped = false;
 
     /**
+     * The last known PID of the task runner.
+     * @var int|null If null, it means the PID is unknown or expired.
+     */
+    private int|null $lastKnownPID = null;
+
+    /**
      * Constructs a status object.
      * @param string $taskID The task ID of the async task so to check its status.
      */
@@ -57,7 +63,7 @@ class AsyncTaskStatus
      * 
      * Note: when this method detects that the task has stopped running, it will not recheck whether the task has restarted.
      * Use a fresh status object to track the (restarted) task.
-     * @return bool
+     * @return bool If true, indicates the task is still running.
      */
     public function isRunning(): bool
     {
@@ -70,5 +76,39 @@ class AsyncTaskStatus
             $this->isStopped = true;
         }
         return $isRunning;
+    }
+
+    /**
+     * Attepts to prove whether the AsyncTask is still running
+     * @return bool If false, then the task is shown to have been stopped.
+     */
+    private function proveTaskIsRunning(): bool
+    {
+        if ($this->lastKnownPID === null) {
+            // we don't know where the task runner is at; find it!
+            return $this->findTaskRunnerProcess();
+        }
+        // we know the task runner; is it still running?
+        return $this->observeTaskRunnerProcess();
+    }
+
+    /**
+     * Attempts to find the task runner process (if exists), and writes down its PID.
+     * @return bool If true, then the task runner is successfully found.
+     */
+    private function findTaskRunnerProcess(): bool
+    {
+        // todo
+        return false;
+    }
+
+    /**
+     * Given a previously-noted PID of the task runner, see if the task runner is still alive.
+     * @return bool If true, then the task runner is still running.
+     */
+    private function observeTaskRunnerProcess(): bool
+    {
+        // todo
+        return false;
     }
 }

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -141,9 +141,10 @@ class AsyncTaskTest extends BaseTestCase
         $task = new AsyncTask($timeoutTask);
         $task->withTimeLimit(1)->start();
         // we wait for it to timeout
-        $this->sleep(0.5);
-        $this->sleep(0.5);
-        $this->sleep(0.5);
+        $this->sleep(0.4);
+        $this->sleep(0.4);
+        $this->sleep(0.4);
+        $this->sleep(0.4);
         // should have timed out
         $this->assertFileExists($textFilePath, "The async task probably did not trigger its timeout handler because its timeout output file is not found.");
         $this->assertStringEqualsFile($textFilePath, $message);

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -222,6 +222,8 @@ class AsyncTaskTest extends BaseTestCase
         // has ID is also ok
         $task = new AsyncTask(new SleepingAsyncTask(), taskID: "yeah");
         unset($task);
+        $taskStatus = new AsyncTaskStatus("yeah");
+        unset($taskStatus);
 
         // but blank ID is not allowed
         $this->expectException(InvalidArgumentException::class);

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -247,7 +247,10 @@ class AsyncTaskTest extends BaseTestCase
         // now we start running the task
         $liveStatus = $task->start();
 
-        // the task is to sleep for 2 seconds, and then exit.
+        // try to sleep a bit, to stabilize the test case
+        sleep(1);
+
+        // the task is to sleep for some time, and then exit.
         // note: since checking the task statuses take some time, we cannot confirm the actual elapsed time of our tests,
         // and so "task ended" case is not testable
         $this->assertFalse($preStatus->isRunning(), "Stopped tasks should always report \"task stopped\".");

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -258,4 +258,29 @@ class AsyncTaskTest extends BaseTestCase
         $this->assertFalse($preStatus->isRunning(), "Stopped tasks should always report \"task stopped\".");
         $this->assertTrue($liveStatus->isRunning(), "Recently-started task does not report \"task running\".");
     }
+
+    public function testAsyncTaskStatusWithTimeLimit()
+    {
+        // test that the task status reading is correct, even if we are using a time limit
+        $taskID = "timeoutTestingTask";
+        $task = new AsyncTask(new SleepingAsyncTask(), taskID: $taskID);
+
+        // we haven't started yet, so this should say false 
+        $preStatus = new AsyncTaskStatus($taskID);
+        $this->assertFalse($preStatus->isRunning());
+        // note: since it detects false, it will always continue to say false
+        $this->assertFalse($preStatus->isRunning());
+
+        // now we start running the task
+        $liveStatus = $task->withTimeLimit(4)->start();
+
+        // try to sleep a bit, to stabilize the test case
+        $this->sleep(0.1);
+
+        // the task is to sleep for some time, and then exit.
+        // note: since checking the task statuses take some time, we cannot confirm the actual elapsed time of our tests,
+        // and so "task ended" case is not testable
+        $this->assertFalse($preStatus->isRunning(), "Stopped tasks should always report \"task stopped\".");
+        $this->assertTrue($liveStatus->isRunning(), "Recently-started task does not report \"task running\".");
+    }
 }

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -248,7 +248,7 @@ class AsyncTaskTest extends BaseTestCase
         $liveStatus = $task->start();
 
         // try to sleep a bit, to stabilize the test case
-        sleep(1);
+        $this->sleep(0.1);
 
         // the task is to sleep for some time, and then exit.
         // note: since checking the task statuses take some time, we cannot confirm the actual elapsed time of our tests,

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -231,4 +231,31 @@ class AsyncTaskTest extends BaseTestCase
         $taskStatus = new AsyncTaskStatus("");
         unset($taskStatus);
     }
+
+    public function testAsyncTaskNormalStatus()
+    {
+        // test that the task status reading is correct
+        $taskID = "testingTask";
+        $task = new AsyncTask(new SleepingAsyncTask(), taskID: $taskID);
+
+        // we haven't started yet, so this should say false 
+        $preStatus = new AsyncTaskStatus($taskID);
+        $this->assertFalse($preStatus->isRunning());
+        // note: since it detects false, it will always continue to say false
+        $this->assertFalse($preStatus->isRunning());
+
+        // now we start running the task
+        $liveStatus = $task->start();
+
+        // the task is to sleep for 2 seconds, and then exit.
+        for ($i = 0; $i < 2; $i++) {
+            // check the statuses; most likely still be running
+            $this->assertFalse($preStatus->isRunning(), "Incorrect pre-run task status at loop $i");
+            $this->assertTrue($liveStatus->isRunning(), "Incorrect live-run task status at loop $i");
+            $this->sleep(0.9);
+        }
+        // should have finished
+        $this->assertFalse($preStatus->isRunning(), "Incorrect pre-run task status at loop end");
+        $this->assertFalse($liveStatus->isRunning(), "Incorrect live-run task status at loop end");
+    }
 }

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -141,10 +141,12 @@ class AsyncTaskTest extends BaseTestCase
         $task = new AsyncTask($timeoutTask);
         $task->withTimeLimit(1)->start();
         // we wait for it to timeout
-        $this->sleep(0.4);
-        $this->sleep(0.4);
-        $this->sleep(0.4);
-        $this->sleep(0.4);
+        $this->sleep(0.3);
+        $this->sleep(0.3);
+        $this->sleep(0.3);
+        $this->sleep(0.3);
+        $this->sleep(0.3);
+        $this->sleep(0.3);
         // should have timed out
         $this->assertFileExists($textFilePath, "The async task probably did not trigger its timeout handler because its timeout output file is not found.");
         $this->assertStringEqualsFile($textFilePath, $message);

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -248,14 +248,9 @@ class AsyncTaskTest extends BaseTestCase
         $liveStatus = $task->start();
 
         // the task is to sleep for 2 seconds, and then exit.
-        for ($i = 0; $i < 2; $i++) {
-            // check the statuses; most likely still be running
-            $this->assertFalse($preStatus->isRunning(), "Incorrect pre-run task status at loop $i");
-            $this->assertTrue($liveStatus->isRunning(), "Incorrect live-run task status at loop $i");
-            $this->sleep(0.9);
-        }
-        // should have finished
-        $this->assertFalse($preStatus->isRunning(), "Incorrect pre-run task status at loop end");
-        $this->assertFalse($liveStatus->isRunning(), "Incorrect live-run task status at loop end");
+        // note: since checking the task statuses take some time, we cannot confirm the actual elapsed time of our tests,
+        // and so "task ended" case is not testable
+        $this->assertFalse($preStatus->isRunning(), "Stopped tasks should always report \"task stopped\".");
+        $this->assertTrue($liveStatus->isRunning(), "Recently-started task does not report \"task running\".");
     }
 }

--- a/tests/AsyncTaskTest.php
+++ b/tests/AsyncTaskTest.php
@@ -2,10 +2,13 @@
 
 namespace Vectorial1024\LaravelProcessAsync\Tests;
 
+use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 use Vectorial1024\LaravelProcessAsync\AsyncTask;
+use Vectorial1024\LaravelProcessAsync\AsyncTaskStatus;
 use Vectorial1024\LaravelProcessAsync\Tests\Tasks\DummyAsyncTask;
+use Vectorial1024\LaravelProcessAsync\Tests\Tasks\SleepingAsyncTask;
 use Vectorial1024\LaravelProcessAsync\Tests\Tasks\TestTimeoutENoticeTask;
 use Vectorial1024\LaravelProcessAsync\Tests\Tasks\TestTimeoutErrorTask;
 use Vectorial1024\LaravelProcessAsync\Tests\Tasks\TestTimeoutNoOpTask;
@@ -203,5 +206,26 @@ class AsyncTaskTest extends BaseTestCase
         // should have timed out
         $this->assertFileDoesNotExist($textFilePath, "The async task timeout handler was inappropriately triggered (E_NOTICE should not trigger timeouts).");
         $this->assertNoNohupFile();
+    }
+
+    public function testAsyncTaskID()
+    {
+        // test that we can correctly handle good and bad task IDs
+
+        // no ID is ok
+        $task = new AsyncTask(new SleepingAsyncTask());
+        unset($task);
+
+        // has ID is also ok
+        $task = new AsyncTask(new SleepingAsyncTask(), taskID: "yeah");
+        unset($task);
+
+        // but blank ID is not allowed
+        $this->expectException(InvalidArgumentException::class);
+        $task = new AsyncTask(new SleepingAsyncTask(), taskID: "");
+        unset($task);
+        $this->expectException(InvalidArgumentException::class);
+        $taskStatus = new AsyncTaskStatus("");
+        unset($taskStatus);
     }
 }

--- a/tests/Tasks/SleepingAsyncTask.php
+++ b/tests/Tasks/SleepingAsyncTask.php
@@ -6,7 +6,7 @@ use Vectorial1024\LaravelProcessAsync\AsyncTaskInterface;
 
 class SleepingAsyncTask implements AsyncTaskInterface
 {
-    // just sleeps for 2 seconds, and finish
+    // just sleeps for 5 seconds, and finish
 
     public function __construct()
     {
@@ -14,7 +14,7 @@ class SleepingAsyncTask implements AsyncTaskInterface
 
     public function execute(): void
     {
-        sleep(2);
+        sleep(5);
     }
 
     public function handleTimeout(): void

--- a/tests/Tasks/SleepingAsyncTask.php
+++ b/tests/Tasks/SleepingAsyncTask.php
@@ -6,7 +6,7 @@ use Vectorial1024\LaravelProcessAsync\AsyncTaskInterface;
 
 class SleepingAsyncTask implements AsyncTaskInterface
 {
-    // just sleeps for 5 seconds, and finish
+    // just sleeps for 2 seconds, and finish
 
     public function __construct()
     {
@@ -14,7 +14,7 @@ class SleepingAsyncTask implements AsyncTaskInterface
 
     public function execute(): void
     {
-        sleep(5);
+        sleep(2);
     }
 
     public function handleTimeout(): void

--- a/tests/Tasks/SleepingAsyncTask.php
+++ b/tests/Tasks/SleepingAsyncTask.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Vectorial1024\LaravelProcessAsync\Tests\Tasks;
+
+use Vectorial1024\LaravelProcessAsync\AsyncTaskInterface;
+
+class SleepingAsyncTask implements AsyncTaskInterface
+{
+    // just sleeps for 5 seconds, and finish
+
+    public function __construct()
+    {
+    }
+
+    public function execute(): void
+    {
+        sleep(5);
+    }
+
+    public function handleTimeout(): void
+    {
+        // nothing for now
+    }
+}


### PR DESCRIPTION
Every running AsyncTask shall have an ID. This can be provided by the user (assuming they do not start multiple tasks with the same ID...), or if the user does not provide one, the ID will be randomly generated instead.

This allows the user to check whether the task is running or not. When the task is no longer running, the user may then use their own code to determine whether it was a success or failure.